### PR TITLE
fix zlib download URL

### DIFF
--- a/vendor/zlib/Makefile
+++ b/vendor/zlib/Makefile
@@ -1,5 +1,5 @@
 VERSION=1.2.7
-URL=http://zlib.net/zlib-$(VERSION).tar.gz
+URL=http://downloads.sourceforge.net/project/libpng/zlib/$(VERSION)/zlib-$(VERSION).tar.gz
 TARBALL=$(shell basename $(URL))
 WORKDIR=zlib-$(VERSION)
 


### PR DESCRIPTION
Since zlib 1.2.8 was released, fetching 1.2.7 from zlib.net is broken. sf.net seem to keep an archive of older releases up.

BTW, building against 1.2.8 works fine.
