### PR TITLE
Updated zlib version in makefile.

### DIFF
--- a/vendor/zlib/Makefile
+++ b/vendor/zlib/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.2.7
+VERSION=1.2.8
 URL=http://zlib.net/zlib-$(VERSION).tar.gz
 TARBALL=$(shell basename $(URL))
 WORKDIR=zlib-$(VERSION)


### PR DESCRIPTION
make[1]: Entering directory `/root/lumberjack/vendor/zlib'
fetch.sh -o zlib-1.2.7.tar.gz "http://zlib.net/zlib-1.2.7.tar.gz"
-o zlib-1.2.7.tar.gz http://zlib.net/zlib-1.2.7.tar.gz
-o zlib-1.2.7.tar.gz -- http://zlib.net/zlib-1.2.7.tar.gz
URL: http://zlib.net/zlib-1.2.7.tar.gz
--2013-05-01 02:43:34--  http://zlib.net/zlib-1.2.7.tar.gz
Resolving zlib.net... 69.73.181.135
Connecting to zlib.net|69.73.181.135|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2013-05-01 02:43:34 ERROR 404: Not Found.

make[1]: **\* [zlib-1.2.7.tar.gz] Error 8
make[1]: Leaving directory `/root/lumberjack/vendor/zlib'
make: **\* [build/include/zlib.h] Error 2

http://zlib.net/

URL: http://zlib.net/zlib-1.2.8.tar.gz
--2013-05-01 12:19:48--  http://zlib.net/zlib-1.2.8.tar.gz
Resolving zlib.net... 69.73.181.135
Connecting to zlib.net|69.73.181.135|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 571091 (558K) [application/x-gzip]
Saving to: “zlib-1.2.8.tar.gz”

100%[======================================================================================================================>] 571,091      901K/s   in 0.6s    

2013-05-01 12:19:49 (901 KB/s) - “zlib-1.2.8.tar.gz” saved [571091/571091]
