### PR TITLE
Fix bundler warning about http rubygems access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gem "rspec"
 gem "insist"
 gem "stud"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bouncy-castle-java (1.5.0146.1)
     diff-lcs (1.1.3)


### PR DESCRIPTION
Simple fix that makes things a bit safer, and removes this bundler warning:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
