### PR TITLE
TypoFix on README json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ include them in your config.:
           "paths": [
             "/var/log/apache/httpd-*.log"
           ],
-          "fields": { "type:" "apache" }
+          "fields": { "type": "apache" }
         }
       ]
     }


### PR DESCRIPTION
There is a colon misplaced. I copied the json file an realized something was wrong with the copied json.
