### PR TITLE
move FileState into platform specific structures

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,10 +11,3 @@ type FileEvent struct {
 
   fileinfo *os.FileInfo
 }
-
-type FileState struct {
-  Source *string `json:"source,omitempty"`
-  Offset int64 `json:"offset,omitempty"`
-  Inode uint64 `json:"inode,omitempty"`
-  Device int32 `json:"device,omitempty"`
-}

--- a/filestate_darwin.go
+++ b/filestate_darwin.go
@@ -1,0 +1,8 @@
+package main
+
+type FileState struct {
+  Source *string `json:"source,omitempty"`
+  Offset int64 `json:"offset,omitempty"`
+  Inode uint64 `json:"inode,omitempty"`
+  Device int32 `json:"device,omitempty"`
+}

--- a/filestate_linux.go
+++ b/filestate_linux.go
@@ -1,0 +1,8 @@
+package main
+
+type FileState struct {
+  Source *string `json:"source,omitempty"`
+  Offset int64 `json:"offset,omitempty"`
+  Inode uint64 `json:"inode,omitempty"`
+  Device uint64 `json:"device,omitempty"`
+}


### PR DESCRIPTION
Since the values for Device (and possibly Inode) can have different data types depending on the host OS, move FileState into platform specific files. This resolves https://github.com/jordansissel/lumberjack/issues/63
