### PR TITLE
Add option to read new files from the top

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -105,6 +105,8 @@ func (h *Harvester) open() *os.File {
   // TODO(sissel): Only seek if the file is a file, not a pipe or socket.
   if h.Offset > 0 {
     h.file.Seek(h.Offset, os.SEEK_SET)
+  } else if *from_beginning {
+    h.file.Seek(0, os.SEEK_SET)
   } else {
     h.file.Seek(0, os.SEEK_END)
   }

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -14,6 +14,7 @@ var spool_size = flag.Uint64("spool-size", 1024, "Maximum number of events to sp
 var idle_timeout = flag.Duration("idle-flush-time", 5 * time.Second, "Maximum time to wait for a full spool before flushing anyway")
 var config_file = flag.String("config", "", "The config file to load")
 var use_syslog = flag.Bool("log-to-syslog", false, "Log to syslog instead of stdout")
+var from_beginning = flag.Bool("from-beginning", false, "Read new files from the beginning, instead of the end")
 
 func main() {
   flag.Parse()


### PR DESCRIPTION
The `-from-beginning` switch will read new files from the start, rather than the end.
Handy if you want to import the whole existing log file, instead of just new events.
