### PR TITLE
Fixing for starting at correct offset for monitored files (Issue #61)

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -63,6 +63,17 @@ func main() {
     log.SetOutput(writer)
   }
 
+  //Ensure there is a register file, if not create one.
+  // TODO Verify we can write to the file
+  if _, err := os.Stat(".lumberjack"); os.IsNotExist(err) {
+      log.Print("Creating new registrar file.")
+      _, err := os.Create(".lumberjack")
+      if err != nil {
+        //Fatal if we cant create a regiser file we can correct track files, better to know now.
+        log.Fatal("Error creating registrar file: ", err)
+      }
+  }
+
   // Prospect the globs/paths given on the command line and launch harvesters
   for _, fileconfig := range config.Files {
     go Prospect(fileconfig, event_chan)

--- a/prospector.go
+++ b/prospector.go
@@ -41,7 +41,7 @@ func resume_tracking(fileconfig FileConfig, fileinfo map[string]os.FileInfo, out
   history, err := os.Open(".lumberjack")
   if err == nil {
     historical_state := make(map[string]*FileState)
-    log.Printf("Loading registrar data\n")
+    log.Printf("Loading registrar data %s\n", fileconfig.Paths)
     decoder := json.NewDecoder(history)
     decoder.Decode(&historical_state)
     history.Close()

--- a/registrar.go
+++ b/registrar.go
@@ -10,7 +10,7 @@ import (
 func Registrar(input chan []*FileEvent) {
   for events := range input {
     state := make(map[string]*FileState)
-    log.Printf("Registrar received %d events\n", len(events))
+    log.Printf("Registrar received %d events for %s\n", len(events), *events[0].Source)
     // Take the last event found for each file source
     for _, event := range events {
       // skip stdin
@@ -33,21 +33,42 @@ func Registrar(input chan []*FileEvent) {
 
     if len(state) > 0 {
       write(state)
-      os.Rename(".lumberjack.new", ".lumberjack")
     }
   }
 }
 
 func write(state map[string]*FileState) {
-  log.Printf("Saving registrar state.\n")
   // Open tmp file, write, flush, rename
-  file, err := os.Create(".lumberjack.new")
+  log.Printf("Saving registrar state.\n")
+
+  //read the current state file and overwrite the current state vaules
+  historical_state := make(map[string]*FileState)
+  history, err := os.Open(".lumberjack")
   if err != nil {
-    log.Printf("Failed to open .lumberjack.new for writing: %s\n", err)
+    log.Printf("Registar was unable to read privous states. Error: %s\n", err)
     return
+  } else {
+    decoder := json.NewDecoder(history)
+    decoder.Decode(&historical_state)
+    history.Close()
+
   }
 
-  encoder := json.NewEncoder(file)
-  encoder.Encode(state)
-  file.Close()
+    //loop though the sate for the file, should be a map of lenght 1
+    for path, new_state := range state {
+      historical_state[path] = new_state
+    }
+
+    file, err := os.Create(".lumberjack.new")
+    if err != nil {
+      log.Printf("Failed to open .lumberjack.new for writing new state: %s\n", err)
+      return
+    }
+
+    encoder := json.NewEncoder(file)
+    encoder.Encode(historical_state)
+    file.Close()
+
+  os.Rename(".lumberjack.new", ".lumberjack")
+
 }


### PR DESCRIPTION
There are two commits here they close issue  #61

https://github.com/jordansissel/lumberjack/issues/61#issuecomment-24119786

The first one 28dc5d4, is a recommit of PR #84.  I think I messed up the PR and it did not merge.

The second commit address the issue that when following more that one file, the registrar file was only the last file.
