### PR TITLE
Start reading from beginning when file is rotated

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -103,7 +103,7 @@ func (h *Harvester) open() *os.File {
   }
 
   // TODO(sissel): Only seek if the file is a file, not a pipe or socket.
-  if h.Offset > 0 {
+  if h.Offset >= 0 {
     h.file.Seek(h.Offset, os.SEEK_SET)
   } else if *from_beginning {
     h.file.Seek(0, os.SEEK_SET)


### PR DESCRIPTION
Launching a new harvester on a rotated file will start at the end. This (hopefully) fixes that. 