### PR TITLE
Alter CA handling to allow for PEMs containing multiple certificates

### DIFF
--- a/publisher1.go
+++ b/publisher1.go
@@ -133,11 +133,10 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
       log.Fatalf("This is not a certificate file: %s\n", config.SSLCA)
     }
 
-    cert, err := x509.ParseCertificate(block.Bytes)
-    if err != nil {
-      log.Fatalf("Failed to parse a certificate: %s\n", config.SSLCA)
+    ok := tlsconfig.RootCAs.AppendCertsFromPEM(pemdata)
+    if ok != true {
+      log.Fatalf("Failed to load any certificates from file: %s\n", config.SSLCA)
     }
-    tlsconfig.RootCAs.AddCert(cert)
   }
 
   for {


### PR DESCRIPTION
Had an issue with authenticating a self-signed certificate that should have been verified by a provided CA file.

This fixes the issue so that CA files containing 1 or more certificates are handled correctly.