### PR TITLE
Always harvest a log that is configured

### DIFF
--- a/prospector.go
+++ b/prospector.go
@@ -109,12 +109,8 @@ func prospector_scan(path string, fields map[string]string,
     // Conditions for starting a new harvester:
     // - file path hasn't been seen before
     // - the file's inode or device changed
-    if !is_known { 
-      // TODO(sissel): Skip files with modification dates older than N
-      // TODO(sissel): Make the 'ignore if older than N' tunable
-      if time.Since(info.ModTime()) > 24*time.Hour {
-        log.Printf("Skipping old file: %s\n", file)
-      } else if is_file_renamed(file, info, fileinfo) {
+    if !is_known {
+      if is_file_renamed(file, info, fileinfo) {
         // Check to see if this file was simply renamed (known inode+dev)
       } else {
         // Most likely a new file. Harvest it!


### PR DESCRIPTION
Discussed in more detail in [googlegroup](https://groups.google.com/forum/#!topic/logstash-users/TwanJlZdho4). I believe logstash-forwarder should always harvest if it exists in the json config. I'm unclear as to why we optimize here and have been burned by the scenario where: 
* log is not rotated every 24hrs
* log was not written to in a 24hr period
* logstash-forwarder is restarted
