### PR TITLE
Fixed the usage of /etc/default/logstash-forwarder. The previous way did...

### DIFF
--- a/logstash-forwarder.init
+++ b/logstash-forwarder.init
@@ -21,11 +21,11 @@ DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 -log-to-syslog"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-COMMAND="cd /var/run; exec $DAEMON $DAEMON_ARGS"
-
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 . /lib/init/vars.sh
 . /lib/lsb/init-functions
+
+COMMAND="cd /var/run; exec $DAEMON $DAEMON_ARGS"
 
 do_start() {
   # Skip if it's already running


### PR DESCRIPTION
Because DEAMON_ARGS was embedded into the COMMAND variable, setting DEAMON_ARGS in /etc/default/logstash-forwarder did not overwrite the used variable.
