### PR TITLE
Support for IPv6 servers

### DIFF
--- a/publisher1.go
+++ b/publisher1.go
@@ -16,11 +16,10 @@ import (
   "compress/zlib"
   "strconv"
   "regexp"
-  "fmt"
 )
 
 var hostname string
-var hostport_re, _ = regexp.Compile("^(.+):([0-9]+)$")
+var hostport_re, _ = regexp.Compile(`^\[?([^]]+)\]?:([0-9]+)$`)
 
 func init() {
   log.Printf("publisher init\n")
@@ -162,7 +161,7 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
     }
 
     address := addresses[rand.Int() % len(addresses)]
-    addressport := fmt.Sprintf("%s:%s", address, port)
+    addressport := net.JoinHostPort(address, port)
 
     log.Printf("Connecting to %s (%s) \n", addressport, host)
 


### PR DESCRIPTION
When a host resolves to an IPv6 address, net.Dial to "addr:port" fails
with "too many colons in address" as the address needs to be enclosed in
square brackets. Use net.JoinHostPort to join them correctly.

Additionally, support square brackets (although not strictly necessary)
in the host specification.