### PR TITLE
Fix an off-by-one error when comparing file size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ include Makefile.ext
 .PHONY: go-check
 go-check:
 	@go version > /dev/null || (echo "Go not found. You need to install go: http://golang.org/doc/install"; false)
-	@go version | grep -q 'go version go1.1' || (echo "Go version 1.1.x required, you have a version of go that is too old See http://golang.org/doc/install for upgrading."; false)
+	@go version | grep -q 'go version go1.[12]' || (echo "Go version 1.1.x (or higher) required, you have a version of go that is too old See http://golang.org/doc/install for upgrading."; false)
 
 
 clean:

--- a/harvester.go
+++ b/harvester.go
@@ -49,8 +49,10 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
         // timed out waiting for data, got eof.
         // Check to see if the file was truncated
         info, _ := h.file.Stat()
-        if info.Size() < offset {
-          log.Printf("File truncated, seeking to beginning: %s\n", h.Path)
+		cursize := info.Size() + 1
+        if cursize < offset {
+          log.Printf("File truncated, seeking to beginning: %s (size: %s, offset: %s)\n",
+                     h.Path, cursize, offset)
           h.file.Seek(0, os.SEEK_SET)
           offset = 0
         } else if age := time.Since(last_read_time); age > (24 * time.Hour) {


### PR DESCRIPTION
This fixes a subtle bug where if we don't get new entries into a log file for more than 10s we compare the file size to offset, and because the result is off by one we assume that the file has been truncated and read from the beginning.