### PR TITLE
Handle DELETED files . Add support for inode changes ( for the same file )

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -7,6 +7,8 @@ import (
   "io"
   "bufio"
   "time"
+  "regexp"
+  "strconv"
 )
 
 type Harvester struct {
@@ -26,6 +28,9 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
 
   h.open()
   info, _ := h.file.Stat() // TODO(sissel): Check error
+  fd := h.file.Fd()
+
+
   defer h.file.Close()
   //info, _ := file.Stat()
 
@@ -43,13 +48,19 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
   last_read_time := time.Now()
   for {
     text, err := h.readline(reader, read_timeout)
-
     if err != nil {
       if err == io.EOF {
+        info, stat_err := h.file.Stat()
+	fdstring := "/proc/self/fd/"+strconv.Itoa(int(fd))
+	file ,_:= os.Readlink(fdstring)
+	r, _ := regexp.Compile(`\s\(deleted\)`)
+	deleted:= r.MatchString(file)
         // timed out waiting for data, got eof.
         // Check to see if the file was truncated
-        info, _ := h.file.Stat()
-        if info.Size() < offset {
+	if ( stat_err != nil ) {
+          log.Printf("Stopping harvest of %s; got error of Stat call %s \n", h.Path, stat_err.Error())
+          return
+	} else if info.Size() < offset {
           log.Printf("File truncated, seeking to beginning: %s\n", h.Path)
           h.file.Seek(0, os.SEEK_SET)
           offset = 0
@@ -60,7 +71,10 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
           // This file is idle for more than 24 hours. Give up and stop harvesting.
           log.Printf("Stopping harvest of %s; last change was %d seconds ago\n", h.Path, age.Seconds())
           return
-        }
+        } else if ( deleted )  {
+          log.Printf("Stopping harvest of %s; file deleted\n", h.Path )
+          return
+	}
         continue
       } else {
         log.Printf("Unexpected state reading from %s; error: %s\n", h.Path, err)

--- a/prospector.go
+++ b/prospector.go
@@ -123,11 +123,19 @@ func prospector_scan(path string, fields map[string]string,
         go harvester.Harvest(output)
       }
     } else if !is_fileinfo_same(lastinfo, info) {
-      log.Printf("Launching harvester on rotated file: %s\n", file)
-      // TODO(sissel): log 'file rotated' or osmething
-      // Start a harvester on the path; a new file appeared with the same name.
-      harvester := Harvester{Path: file, Fields: fields}
-      go harvester.Harvest(output)
+
+	    _,ok :=  fields["rsync"]
+	    if ok && info.Size() >= lastinfo.Size()  { 
+		    log.Printf("Rsync keyword found for file: %s\n", file)
+		    harvester := Harvester{Path: file, Fields: fields, Offset: lastinfo.Size() }
+		    go harvester.Harvest(output)
+	      } else {
+		      log.Printf("Launching harvester on rotated file: %s\n", file)
+		      // TODO(sissel): log 'file rotated' or osmething
+		      // Start a harvester on the path; a new file appeared with the same name.
+		      harvester := Harvester{Path: file, Fields: fields}
+		      go harvester.Harvest(output)
+	      }
     }
   } // for each file matched by the glob
 }


### PR DESCRIPTION
1. Check /proc/self/fd/ directory and stop harvesting file it it was deleted 

2. Introduced  new configuration  option , rsync . 
 "fields": {  "rsync": "yes" }
We rsync files from remote location and rsync changes inode numbers for some of the files . 
The content of the files is still the same , so we should continue to harvest them .
By default logstash-forwarder will stop harvesting files on inode change . 




