### PR TITLE
Adds a note about the go version that is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ include them in your config.:
 
 ## Building it
 
-1. Install [go](http://golang.org/doc/install)
+1. Install [go](http://golang.org/doc/install) (version 1.1 or better is required)
 
 2. Compile logstash-forwarder
 


### PR DESCRIPTION
Using 1.1 based on https://github.com/elasticsearch/logstash-forwarder/issues/59