### PR TITLE
Add support for hostnames based from SRV records.

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type Config struct {
 
 type NetworkConfig struct {
   Servers        []string `json:servers`
+  UseSRV         bool     `json:"use srv"`
   SSLCertificate string   `json:"ssl certificate"`
   SSLKey         string   `json:"ssl key"`
   SSLCA          string   `json:"ssl ca"`

--- a/publisher1.go
+++ b/publisher1.go
@@ -21,6 +21,7 @@ import (
 
 var hostname string
 var hostport_re, _ = regexp.Compile("^(.+):([0-9]+)$")
+var srvRecordCount int = 0
 
 func init() {
   log.Printf("publisher init\n")
@@ -164,13 +165,7 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 
   for {
     // Pick a random server from the list.
-    hostport := config.Servers[rand.Int()%len(config.Servers)]
-    submatch := hostport_re.FindSubmatch([]byte(hostport))
-    if submatch == nil {
-      log.Fatalf("Invalid host:port given: %s", hostport)
-    }
-    host := string(submatch[1])
-    port := string(submatch[2])
+    host, port := getHostPort(config)
     addresses, err := net.LookupHost(host)
 
     if err != nil {
@@ -207,6 +202,32 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
     return
   }
   return
+}
+
+func getHostPort(config *NetworkConfig) (host, port string) {
+  if(config.UseSRV) {
+    _, addrs, err := net.LookupSRV("lumberjack", "tcp", string(config.Servers[0]))
+    if err != nil {
+      log.Fatalf("Bad domain: %s", string(config.Servers[0]))
+    }
+    if(len(addrs) < srvRecordCount){
+      srvRecordCount = 0
+    }
+    hostport := fmt.Sprintf("%s:%d",addrs[srvRecordCount].Target, addrs[srvRecordCount].Port)
+    host, port, err := net.SplitHostPort(hostport)
+    if err != nil {
+      log.Fatalf("Invalid host:port given: %s", hostport)
+    }
+    return host, port
+  } else {
+    // Pick a random server from the list.
+    hostport := config.Servers[rand.Int()%len(config.Servers)]
+    host, port, err := net.SplitHostPort(hostport)
+    if err != nil {
+      log.Fatalf("Invalid host:port given: %s", hostport)
+    }
+    return host, port
+  }
 }
 
 func writeDataFrame(event *FileEvent, sequence uint32, output io.Writer) {


### PR DESCRIPTION
Basic support for SRV records. If the "use srv" config is set to true then it will use the first host from servers to lookup the SRV record. Currently the service is hardcoded to "lumberjack" and protocol to "tcp" which seem sensible and no need to configure.

Currently only re-queries SRV on reconnect.