### PR TITLE
jls-lumberjack gem to 0.0.20 with version frame to allow backward compatibility

### DIFF
--- a/jls-lumberjack.gemspec
+++ b/jls-lumberjack.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = []
   gem.name          = "jls-lumberjack"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.19"
+  gem.version       = "0.0.20"
 
   gem.add_runtime_dependency "ffi-rzmq", "~> 1.0.0"
 end


### PR DESCRIPTION
Super quick patch to add backwards compatibility to the server module.
Future logstash-forwarder can send "1V<proposed_version>" and server will return "1V<version>" (same or lower than proposed.) Version before frame char couldn't be used for this - send an unknown frame and your connection ends.

Be good to get in LogStash sooner than later to open an easy road for protocol improvements without breaking stuff - if we change protocol though (#119) it becomes irrelevant but if we don't... I think this is important!
