### PR TITLE
Install systemd service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ rpm deb: | build-all
 		--url "https://github.com/elasticsearch/logstash-forwarder" \
 		build/bin/logstash-forwarder=$(PREFIX)/bin/ \
 		build/bin/logstash-forwarder.sh=$(PREFIX)/bin/ \
-		logstash-forwarder.init=/etc/init.d/logstash-forwarder
+		logstash-forwarder.init=/etc/init.d/logstash-forwarder \
+		logstash-forwarder.service=/usr/lib/systemd/system/logstash-forwarder.service
 
 # Vendor'd dependencies
 # If VENDOR contains 'zeromq' download and build it.

--- a/logstash-forwarder.service
+++ b/logstash-forwarder.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Logstash Forwarder
+After=syslog.target
+
+[Service]
+ExecStart=/opt/logstash-forwarder/bin/logstash-forwarder -config /etc/logstash-forwarder.conf -spool-size 100 -log-to-syslog
+Restart=on-failure
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This implements a systemd service unit for the forwarder.

This will be useful for future releases of debian and rhel, while already needed for most other distributions and customized debian installations with systemd.