### PR TITLE
Obey the -from-beginning cl arg

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -105,10 +105,10 @@ func (h *Harvester) open() *os.File {
   }
 
   // TODO(sissel): Only seek if the file is a file, not a pipe or socket.
-  if h.Offset > 0 {
-    h.file.Seek(h.Offset, os.SEEK_SET)
-  } else if *from_beginning {
+  if *from_beginning {
     h.file.Seek(0, os.SEEK_SET)
+  } else if h.Offset > 0 {
+    h.file.Seek(h.Offset, os.SEEK_SET)
   } else {
     h.file.Seek(0, os.SEEK_END)
   }


### PR DESCRIPTION
When started with the `-from-beginning` argument, we should prioritise it.
