### PR TITLE
support for newer SSL certificate types

### DIFF
--- a/publisher1.go
+++ b/publisher1.go
@@ -19,6 +19,10 @@ import (
   "time"
 )
 
+// Support for newer SSL signature algorithms
+import _ "crypto/sha256"
+import _ "crypto/sha512"
+
 var hostname string
 var hostport_re, _ = regexp.Compile("^(.+):([0-9]+)$")
 


### PR DESCRIPTION
More and more CAs (also internal ones, possibly most commonly used with logstash-forwarder) are using certificates signed using SHA256 or SHA512, whereas go's X.509 support by default only supports certificates signed with a SHA1 hash.

This leads to logstash-forwarder failing with

> Failed to tls handshake with xxx.xxx.xxx.xxx x509: certificate signed by unknown authority (possibly because of "x509: cannot verify signature: algorithm unimplemented" while trying to verify candidate authority certificate "Name of the Authority")

The error message isn't very helpful and even if users were capable of easily finding out where the problem is, you can't expect a CA to provide their certificate signed with a different hash, so IMHO these newer certificates should be supported.

Thankfully, supporting them is reduced to importing the two hash functions before connecting.
