### PR TITLE
Support for both Windows and Linux newlines and don't split lines

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -7,6 +7,7 @@ import (
   "log"
   "os" // for File and friends
   "time"
+  "strings"
 )
 
 type Harvester struct {
@@ -70,16 +71,20 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
 
     last_read_time = time.Now()
 
+    // Remove whitespaces from string
+    text_without_newlines := new(string)
+    *text_without_newlines = strings.Trim(*text, "\n\r")
+
     line++
     event := &FileEvent{
       Source:   &h.Path,
       Offset:   offset,
       Line:     line,
-      Text:     text,
+      Text:     text_without_newlines,
       Fields:   &h.Fields,
       fileinfo: &info,
     }
-    offset += int64(len(*event.Text)) + 1 // +1 because of the line terminator
+    offset += int64(len(*text))
 
     output <- event // ship the new event downstream
   } /* forever */


### PR DESCRIPTION
I noticed that when a line got split when writing logstash-forwarder either sent both halves of the line as separate events or detected it as a file truncation. Besides, the +1 on the offset assumed only linux type newlines (\n) and could have funky behavior with windows style newlines (\r\n).

I changed the code a bit to allow the files being monitored to have split lines momentarily, I hope it can help someone.