### PR TITLE
Fix state file persistence

### DIFF
--- a/registrar.go
+++ b/registrar.go
@@ -5,8 +5,8 @@ import (
 )
 
 func Registrar(input chan []*FileEvent) {
+  state := make(map[string]*FileState)
   for events := range input {
-    state := make(map[string]*FileState)
     log.Printf("Registrar received %d events\n", len(events))
     // Take the last event found for each file source
     for _, event := range events {


### PR DESCRIPTION
This ensures the state persists correctly when monitoring more than one file.

Currently it will wipe the state on each flush and only persist for files involved in that flush. This makes it keep the last state and just update it.
