### PR TITLE
Added 'preferred server' logic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ include them in your config.:
     {
       # The network section covers network configuration :)
       "network": {
+        # Define a preferred server (optional)
+        # The server must be defined in the 'servers' list below as well
+        "preferred server": "localhost:5053",
+
         # A list of downstream servers listening for our messages.
         # logstash-forwarder will pick one at random and only switch if
         # the selected one appears to be dead or unresponsive

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 }
 
 type NetworkConfig struct {
+  PreferredServer string   `json:"preferred server"`
   Servers        []string `json:servers`
   SSLCertificate string   `json:"ssl certificate"`
   SSLKey         string   `json:"ssl key"`

--- a/publisher1.go
+++ b/publisher1.go
@@ -166,9 +166,25 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
     tlsconfig.RootCAs.AddCert(cert)
   }
 
+  var preferred bool
+  if len(config.PreferredServer) > 0 {
+    preferred = true
+  } else {
+    preferred = false
+  }
+
   for {
-    // Pick a random server from the list.
-    hostport := config.Servers[rand.Int()%len(config.Servers)]
+    hostport := ""
+    if preferred {
+      // Try preferred server first, if defined
+      log.Printf("Trying to connect to preferred server %s", config.PreferredServer)
+      hostport = config.PreferredServer
+      preferred = false
+    } else {
+      // Pick a random server from the list.
+      hostport = config.Servers[rand.Int()%len(config.Servers)]
+    }
+
     submatch := hostport_re.FindSubmatch([]byte(hostport))
     if submatch == nil {
       log.Fatalf("Invalid host:port given: %s", hostport)


### PR DESCRIPTION
The random connection to a backend on startup is fine with many nodes but can lead to an unbalanced workload in a small environment. 
This adds the option to connect to a defined server first, with the old behaviour as a fallback. 