### PR TITLE
Allows builds using go 1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ include Makefile.ext
 .PHONY: go-check
 go-check:
 	@go version > /dev/null || (echo "Go not found. You need to install go: http://golang.org/doc/install"; false)
-	@go version | grep -q 'go version go1.[12]' || (echo "Go version 1.1.x (or higher) required, you have a version of go that is too old See http://golang.org/doc/install for upgrading."; false)
+	@go version | grep -q 'go version go1.[123]' || (echo "Go version 1.1.x (or higher) required, you have a version of go that is too old See http://golang.org/doc/install for upgrading."; false)
 
 
 clean:


### PR DESCRIPTION
'make deb' (and I would assume 'make rpm') currently fails when using the latest version of go (1.3) installed from godeb per https://github.com/elasticsearch/logstash-forwarder/issues/104.  This change resolves the make failures.
