### PR TITLE
Actually use the passed 'address' to bind the TCP port

### DIFF
--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -31,7 +31,7 @@ module Lumberjack
         end
       end
 
-      @tcp_server = TCPServer.new(@options[:port])
+      @tcp_server = TCPServer.new(@options[:address], @options[:port])
       # Query the port in case the port number is '0'
       # TCPServer#addr == [ address_family, port, address, address ]
       @port = @tcp_server.addr[1]


### PR DESCRIPTION
Before the 'address' was not used at all and the service
was bound to all interfaces on the host.

I hope this is ok this way. This is the first time I write any Ruby code :).
Though I tested the changes on my server and observed the result with `netstat -l`.