### PR TITLE
option to disable TLS server name check and registrar lose/overwrite historical data

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,67 +1,67 @@
 package main
 
 import (
-  "encoding/json"
-  "log"
-  "os"
-  "time"
+	"encoding/json"
+	"log"
+	"os"
+	"time"
 )
 
 type Config struct {
-  Network NetworkConfig `json:network`
-  Files   []FileConfig  `json:files`
+	Network NetworkConfig `json:network`
+	Files   []FileConfig  `json:files`
 }
 
 type NetworkConfig struct {
-  Servers        []string `json:servers`
-  SSLCertificate string   `json:"ssl certificate"`
-  SSLKey         string   `json:"ssl key"`
-  SSLCA          string   `json:"ssl ca"`
-  Timeout        int64    `json:timeout`
-  timeout        time.Duration
+	Servers        []string `json:servers`
+	SSLCertificate string   `json:"ssl certificate"`
+	SSLKey         string   `json:"ssl key"`
+	SSLCA          string   `json:"ssl ca"`
+	Timeout        int64    `json:timeout`
+	timeout        time.Duration
 }
 
 type FileConfig struct {
-  Paths  []string          `json:paths`
-  Fields map[string]string `json:fields`
-  //DeadTime time.Duration `json:"dead time"`
+	Paths  []string          `json:paths`
+	Fields map[string]string `json:fields`
+	//DeadTime time.Duration `json:"dead time"`
 }
 
 func LoadConfig(path string) (config Config, err error) {
-  config_file, err := os.Open(path)
-  if err != nil {
-    log.Printf("Failed to open config file '%s': %s\n", path, err)
-    return
-  }
+	config_file, err := os.Open(path)
+	if err != nil {
+		log.Printf("Failed to open config file '%s': %s\n", path, err)
+		return
+	}
 
-  fi, _ := config_file.Stat()
-  if fi.Size() > (10 << 20) {
-    log.Printf("Config file too large? Aborting, just in case. '%s' is %d bytes\n",
-      path, fi)
-    return
-  }
+	fi, _ := config_file.Stat()
+	if fi.Size() > (10 << 20) {
+		log.Printf("Config file too large? Aborting, just in case. '%s' is %d bytes\n",
+			path, fi)
+		return
+	}
 
-  buffer := make([]byte, fi.Size())
-  _, err = config_file.Read(buffer)
-  log.Printf("%s\n", buffer)
+	buffer := make([]byte, fi.Size())
+	_, err = config_file.Read(buffer)
+	log.Printf("%s\n", buffer)
 
-  err = json.Unmarshal(buffer, &config)
-  if err != nil {
-    log.Printf("Failed unmarshalling json: %s\n", err)
-    return
-  }
+	err = json.Unmarshal(buffer, &config)
+	if err != nil {
+		log.Printf("Failed unmarshalling json: %s\n", err)
+		return
+	}
 
-  if config.Network.Timeout == 0 {
-    config.Network.Timeout = 15
-  }
+	if config.Network.Timeout == 0 {
+		config.Network.Timeout = 15
+	}
 
-  config.Network.timeout = time.Duration(config.Network.Timeout) * time.Second
+	config.Network.timeout = time.Duration(config.Network.Timeout) * time.Second
 
-  //for _, fileconfig := range config.Files {
-  //if fileconfig.DeadTime == 0 {
-  //fileconfig.DeadTime = 24 * time.Hour
-  //}
-  //}
+	//for _, fileconfig := range config.Files {
+	//if fileconfig.DeadTime == 0 {
+	//fileconfig.DeadTime = 24 * time.Hour
+	//}
+	//}
 
-  return
+	return
 }

--- a/harvester.go
+++ b/harvester.go
@@ -1,153 +1,154 @@
 package main
 
 import (
-  "bufio"
-  "bytes"
-  "io"
-  "log"
-  "os" // for File and friends
-  "time"
+	"bufio"
+	"bytes"
+	"io"
+	"log"
+	"os" // for File and friends
+	"time"
 )
 
 type Harvester struct {
-  Path   string /* the file path to harvest */
-  Fields map[string]string
-  Offset int64
+	Path   string /* the file path to harvest */
+	Fields map[string]string
+	Offset int64
 
-  file *os.File /* the file being watched */
+	file *os.File /* the file being watched */
 }
 
 func (h *Harvester) Harvest(output chan *FileEvent) {
-  if h.Offset > 0 {
-    log.Printf("Starting harvester at position %d: %s\n", h.Offset, h.Path)
-  } else {
-    log.Printf("Starting harvester: %s\n", h.Path)
-  }
+	if h.Offset > 0 {
+		log.Printf("Starting harvester at position %d: %s\n", h.Offset, h.Path)
+	} else {
+		log.Printf("Starting harvester: %s\n", h.Path)
+	}
 
-  h.open()
-  info, _ := h.file.Stat() // TODO(sissel): Check error
-  defer h.file.Close()
-  //info, _ := file.Stat()
+	h.open()
+	info, _ := h.file.Stat() // TODO(sissel): Check error
+	defer h.file.Close()
+	//info, _ := file.Stat()
 
-  var line uint64 = 0 // Ask registrar about the line number
+	var line uint64 = 0 // Ask registrar about the line number
 
-  // get current offset in file
-  offset, _ := h.file.Seek(0, os.SEEK_CUR)
+	// get current offset in file
+	offset, _ := h.file.Seek(0, os.SEEK_CUR)
 
-  log.Printf("Current file offset: %d\n", offset)
+	log.Printf("Current file offset: %d\n", offset)
 
-  // TODO(sissel): Make the buffer size tunable at start-time
-  reader := bufio.NewReaderSize(h.file, 16<<10) // 16kb buffer by default
+	// TODO(sissel): Make the buffer size tunable at start-time
+	reader := bufio.NewReaderSize(h.file, 16<<10) // 16kb buffer by default
 
-  var read_timeout = 10 * time.Second
-  last_read_time := time.Now()
-  for {
-    text, err := h.readline(reader, read_timeout)
+	var read_timeout = 10 * time.Second
+	last_read_time := time.Now()
+	for {
+		text, err := h.readline(reader, read_timeout)
 
-    if err != nil {
-      if err == io.EOF {
-        // timed out waiting for data, got eof.
-        // Check to see if the file was truncated
-        info, _ := h.file.Stat()
-        if info.Size() < offset {
-          log.Printf("File truncated, seeking to beginning: %s\n", h.Path)
-          h.file.Seek(0, os.SEEK_SET)
-          offset = 0
-        } else if age := time.Since(last_read_time); age > (24 * time.Hour) {
-          // if last_read_time was more than 24 hours ago, this file is probably
-          // dead. Stop watching it.
-          // TODO(sissel): Make this time configurable
-          // This file is idle for more than 24 hours. Give up and stop harvesting.
-          log.Printf("Stopping harvest of %s; last change was %d seconds ago\n", h.Path, age.Seconds())
-          return
-        }
-        continue
-      } else {
-        log.Printf("Unexpected state reading from %s; error: %s\n", h.Path, err)
-        return
-      }
-    }
-    last_read_time = time.Now()
+		if err != nil {
+			if err == io.EOF {
+				// timed out waiting for data, got eof.
+				// Check to see if the file was truncated
+				info, _ := h.file.Stat()
+				if info.Size() < offset {
+					log.Printf("File truncated, seeking to beginning: %s\n", h.Path)
+					log.Printf("file stat offset is %s, our offset is %s\n", info.Size(), offset)
+					h.file.Seek(0, os.SEEK_SET)
+					offset = 0
+				} else if age := time.Since(last_read_time); age > (24 * time.Hour) {
+					// if last_read_time was more than 24 hours ago, this file is probably
+					// dead. Stop watching it.
+					// TODO(sissel): Make this time configurable
+					// This file is idle for more than 24 hours. Give up and stop harvesting.
+					log.Printf("Stopping harvest of %s; last change was %d seconds ago\n", h.Path, age.Seconds())
+					return
+				}
+				continue
+			} else {
+				log.Printf("Unexpected state reading from %s; error: %s\n", h.Path, err)
+				return
+			}
+		}
+		last_read_time = time.Now()
 
-    line++
-    event := &FileEvent{
-      Source:   &h.Path,
-      Offset:   offset,
-      Line:     line,
-      Text:     text,
-      Fields:   &h.Fields,
-      fileinfo: &info,
-    }
-    offset += int64(len(*event.Text)) + 1 // +1 because of the line terminator
+		line++
+		event := &FileEvent{
+			Source:   &h.Path,
+			Offset:   offset,
+			Line:     line,
+			Text:     text,
+			Fields:   &h.Fields,
+			fileinfo: &info,
+		}
+		offset += int64(len(*event.Text)) + 1 // +1 because of the line terminator
 
-    output <- event // ship the new event downstream
-  } /* forever */
+		output <- event // ship the new event downstream
+	} /* forever */
 }
 
 func (h *Harvester) open() *os.File {
-  // Special handling that "-" means to read from standard input
-  if h.Path == "-" {
-    h.file = os.Stdin
-    return h.file
-  }
+	// Special handling that "-" means to read from standard input
+	if h.Path == "-" {
+		h.file = os.Stdin
+		return h.file
+	}
 
-  for {
-    var err error
-    h.file, err = os.Open(h.Path)
+	for {
+		var err error
+		h.file, err = os.Open(h.Path)
 
-    if err != nil {
-      // retry on failure.
-      log.Printf("Failed opening %s: %s\n", h.Path, err)
-      time.Sleep(5 * time.Second)
-    } else {
-      break
-    }
-  }
+		if err != nil {
+			// retry on failure.
+			log.Printf("Failed opening %s: %s\n", h.Path, err)
+			time.Sleep(5 * time.Second)
+		} else {
+			break
+		}
+	}
 
-  // TODO(sissel): Only seek if the file is a file, not a pipe or socket.
-  if h.Offset > 0 {
-    h.file.Seek(h.Offset, os.SEEK_SET)
-  } else if *from_beginning {
-    h.file.Seek(0, os.SEEK_SET)
-  } else {
-    h.file.Seek(0, os.SEEK_END)
-  }
+	// TODO(sissel): Only seek if the file is a file, not a pipe or socket.
+	if h.Offset > 0 {
+		h.file.Seek(h.Offset, os.SEEK_SET)
+	} else if *from_beginning {
+		h.file.Seek(0, os.SEEK_SET)
+	} else {
+		h.file.Seek(0, os.SEEK_END)
+	}
 
-  return h.file
+	return h.file
 }
 
 func (h *Harvester) readline(reader *bufio.Reader, eof_timeout time.Duration) (*string, error) {
-  var buffer bytes.Buffer
-  start_time := time.Now()
-  for {
-    segment, is_partial, err := reader.ReadLine()
+	var buffer bytes.Buffer
+	start_time := time.Now()
+	for {
+		segment, is_partial, err := reader.ReadLine()
 
-    if err != nil {
-      if err == io.EOF {
-        time.Sleep(1 * time.Second) // TODO(sissel): Implement backoff
+		if err != nil {
+			if err == io.EOF {
+				time.Sleep(1 * time.Second) // TODO(sissel): Implement backoff
 
-        // Give up waiting for data after a certain amount of time.
-        // If we time out, return the error (eof)
-        if time.Since(start_time) > eof_timeout {
-          return nil, err
-        }
-        continue
-      } else {
-        log.Println(err)
-        return nil, err // TODO(sissel): don't do this?
-      }
-    }
+				// Give up waiting for data after a certain amount of time.
+				// If we time out, return the error (eof)
+				if time.Since(start_time) > eof_timeout {
+					return nil, err
+				}
+				continue
+			} else {
+				log.Println(err)
+				return nil, err // TODO(sissel): don't do this?
+			}
+		}
 
-    // TODO(sissel): if buffer exceeds a certain length, maybe report an error condition? chop it?
-    buffer.Write(segment)
+		// TODO(sissel): if buffer exceeds a certain length, maybe report an error condition? chop it?
+		buffer.Write(segment)
 
-    if !is_partial {
-      // If we got a full line, return the whole line.
-      str := new(string)
-      *str = buffer.String()
-      return str, nil
-    }
-  } /* forever read chunks */
+		if !is_partial {
+			// If we got a full line, return the whole line.
+			str := new(string)
+			*str = buffer.String()
+			return str, nil
+		}
+	} /* forever read chunks */
 
-  return nil, nil
+	return nil, nil
 }

--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-  "flag"
-  "log"
-  "os"
-  "runtime/pprof"
-  "time"
+	"flag"
+	"log"
+	"os"
+	"runtime/pprof"
+	"time"
 )
 
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
@@ -14,60 +14,61 @@ var idle_timeout = flag.Duration("idle-flush-time", 5*time.Second, "Maximum time
 var config_file = flag.String("config", "", "The config file to load")
 var use_syslog = flag.Bool("log-to-syslog", false, "Log to syslog instead of stdout")
 var from_beginning = flag.Bool("from-beginning", false, "Read new files from the beginning, instead of the end")
+var insecure = flag.Bool("insecure", false, "ignore server name in CA certs")
 
 func main() {
-  flag.Parse()
+	flag.Parse()
 
-  if *cpuprofile != "" {
-    f, err := os.Create(*cpuprofile)
-    if err != nil {
-      log.Fatal(err)
-    }
-    pprof.StartCPUProfile(f)
-    go func() {
-      time.Sleep(60 * time.Second)
-      pprof.StopCPUProfile()
-      panic("done")
-    }()
-  }
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		go func() {
+			time.Sleep(60 * time.Second)
+			pprof.StopCPUProfile()
+			panic("done")
+		}()
+	}
 
-  config, err := LoadConfig(*config_file)
-  if err != nil {
-    return
-  }
+	config, err := LoadConfig(*config_file)
+	if err != nil {
+		return
+	}
 
-  event_chan := make(chan *FileEvent, 16)
-  publisher_chan := make(chan []*FileEvent, 1)
-  registrar_chan := make(chan []*FileEvent, 1)
+	event_chan := make(chan *FileEvent, 16)
+	publisher_chan := make(chan []*FileEvent, 1)
+	registrar_chan := make(chan []*FileEvent, 1)
 
-  if len(config.Files) == 0 {
-    log.Fatalf("No paths given. What files do you want me to watch?\n")
-  }
+	if len(config.Files) == 0 {
+		log.Fatalf("No paths given. What files do you want me to watch?\n")
+	}
 
-  // The basic model of execution:
-  // - prospector: finds files in paths/globs to harvest, starts harvesters
-  // - harvester: reads a file, sends events to the spooler
-  // - spooler: buffers events until ready to flush to the publisher
-  // - publisher: writes to the network, notifies registrar
-  // - registrar: records positions of files read
-  // Finally, prospector uses the registrar information, on restart, to
-  // determine where in each file to resume a harvester.
+	// The basic model of execution:
+	// - prospector: finds files in paths/globs to harvest, starts harvesters
+	// - harvester: reads a file, sends events to the spooler
+	// - spooler: buffers events until ready to flush to the publisher
+	// - publisher: writes to the network, notifies registrar
+	// - registrar: records positions of files read
+	// Finally, prospector uses the registrar information, on restart, to
+	// determine where in each file to resume a harvester.
 
-  log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
-  if *use_syslog {
-    configureSyslog()
-  }
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+	if *use_syslog {
+		configureSyslog()
+	}
 
-  // Prospect the globs/paths given on the command line and launch harvesters
-  for _, fileconfig := range config.Files {
-    go Prospect(fileconfig, event_chan)
-  }
+	// Prospect the globs/paths given on the command line and launch harvesters
+	for _, fileconfig := range config.Files {
+		go Prospect(fileconfig, event_chan)
+	}
 
-  // Harvesters dump events into the spooler.
-  go Spool(event_chan, publisher_chan, *spool_size, *idle_timeout)
+	// Harvesters dump events into the spooler.
+	go Spool(event_chan, publisher_chan, *spool_size, *idle_timeout)
 
-  go Publishv1(publisher_chan, registrar_chan, &config.Network)
+	go Publishv1(publisher_chan, registrar_chan, &config.Network)
 
-  // registrar records last acknowledged positions in all files.
-  Registrar(registrar_chan)
+	// registrar records last acknowledged positions in all files.
+	Registrar(registrar_chan)
 } /* main */

--- a/publisher1.go
+++ b/publisher1.go
@@ -1,236 +1,237 @@
 package main
 
 import (
-  "bytes"
-  "compress/zlib"
-  "crypto/tls"
-  "crypto/x509"
-  "encoding/binary"
-  "encoding/pem"
-  "fmt"
-  "io"
-  "io/ioutil"
-  "log"
-  "math/rand"
-  "net"
-  "os"
-  "regexp"
-  "strconv"
-  "time"
+	"bytes"
+	"compress/zlib"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/binary"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
 )
 
 var hostname string
 var hostport_re, _ = regexp.Compile("^(.+):([0-9]+)$")
 
 func init() {
-  log.Printf("publisher init\n")
-  hostname, _ = os.Hostname()
-  rand.Seed(time.Now().UnixNano())
+	log.Printf("publisher init\n")
+	hostname, _ = os.Hostname()
+	rand.Seed(time.Now().UnixNano())
 }
 
 func Publishv1(input chan []*FileEvent,
-  registrar chan []*FileEvent,
-  config *NetworkConfig) {
-  var buffer bytes.Buffer
-  var socket *tls.Conn
-  var sequence uint32
-  var err error
+	registrar chan []*FileEvent,
+	config *NetworkConfig) {
+	var buffer bytes.Buffer
+	var socket *tls.Conn
+	var sequence uint32
+	var err error
 
-  socket = connect(config)
-  defer socket.Close()
+	socket = connect(config)
+	defer socket.Close()
 
-  for events := range input {
-    buffer.Truncate(0)
-    compressor, _ := zlib.NewWriterLevel(&buffer, 3)
+	for events := range input {
+		buffer.Truncate(0)
+		compressor, _ := zlib.NewWriterLevel(&buffer, 3)
 
-    for _, event := range events {
-      sequence += 1
-      writeDataFrame(event, sequence, compressor)
-    }
-    compressor.Flush()
-    compressor.Close()
+		for _, event := range events {
+			sequence += 1
+			writeDataFrame(event, sequence, compressor)
+		}
+		compressor.Flush()
+		compressor.Close()
 
-    compressed_payload := buffer.Bytes()
+		compressed_payload := buffer.Bytes()
 
-    // Send buffer until we're successful...
-    oops := func(err error) {
-      // TODO(sissel): Track how frequently we timeout and reconnect. If we're
-      // timing out too frequently, there's really no point in timing out since
-      // basically everything is slow or down. We'll want to ratchet up the
-      // timeout value slowly until things improve, then ratchet it down once
-      // things seem healthy.
-      log.Printf("Socket error, will reconnect: %s\n", err)
-      time.Sleep(1 * time.Second)
-      socket.Close()
-      socket = connect(config)
-    }
+		// Send buffer until we're successful...
+		oops := func(err error) {
+			// TODO(sissel): Track how frequently we timeout and reconnect. If we're
+			// timing out too frequently, there's really no point in timing out since
+			// basically everything is slow or down. We'll want to ratchet up the
+			// timeout value slowly until things improve, then ratchet it down once
+			// things seem healthy.
+			log.Printf("Socket error, will reconnect: %s\n", err)
+			time.Sleep(1 * time.Second)
+			socket.Close()
+			socket = connect(config)
+		}
 
-  SendPayload:
-    for {
-      // Abort if our whole request takes longer than the configured
-      // network timeout.
-      socket.SetDeadline(time.Now().Add(config.timeout))
+	SendPayload:
+		for {
+			// Abort if our whole request takes longer than the configured
+			// network timeout.
+			socket.SetDeadline(time.Now().Add(config.timeout))
 
-      // Set the window size to the length of this payload in events.
-      _, err = socket.Write([]byte("1W"))
-      if err != nil {
-        oops(err)
-        continue
-      }
-      binary.Write(socket, binary.BigEndian, uint32(len(events)))
-      if err != nil {
-        oops(err)
-        continue
-      }
+			// Set the window size to the length of this payload in events.
+			_, err = socket.Write([]byte("1W"))
+			if err != nil {
+				oops(err)
+				continue
+			}
+			binary.Write(socket, binary.BigEndian, uint32(len(events)))
+			if err != nil {
+				oops(err)
+				continue
+			}
 
-      // Write compressed frame
-      socket.Write([]byte("1C"))
-      if err != nil {
-        oops(err)
-        continue
-      }
-      binary.Write(socket, binary.BigEndian, uint32(len(compressed_payload)))
-      if err != nil {
-        oops(err)
-        continue
-      }
-      _, err = socket.Write(compressed_payload)
-      if err != nil {
-        oops(err)
-        continue
-      }
+			// Write compressed frame
+			socket.Write([]byte("1C"))
+			if err != nil {
+				oops(err)
+				continue
+			}
+			binary.Write(socket, binary.BigEndian, uint32(len(compressed_payload)))
+			if err != nil {
+				oops(err)
+				continue
+			}
+			_, err = socket.Write(compressed_payload)
+			if err != nil {
+				oops(err)
+				continue
+			}
 
-      // read ack
-      response := make([]byte, 0, 6)
-      ackbytes := 0
-      for ackbytes != 6 {
-        n, err := socket.Read(response[len(response):cap(response)])
-        if err != nil {
-          log.Printf("Read error looking for ack: %s\n", err)
-          socket.Close()
-          socket = connect(config)
-          continue SendPayload // retry sending on new connection
-        } else {
-          ackbytes += n
-        }
-      }
+			// read ack
+			response := make([]byte, 0, 6)
+			ackbytes := 0
+			for ackbytes != 6 {
+				n, err := socket.Read(response[len(response):cap(response)])
+				if err != nil {
+					log.Printf("Read error looking for ack: %s\n", err)
+					socket.Close()
+					socket = connect(config)
+					continue SendPayload // retry sending on new connection
+				} else {
+					ackbytes += n
+				}
+			}
 
-      // TODO(sissel): verify ack
-      // Success, stop trying to send the payload.
-      break
-    }
+			// TODO(sissel): verify ack
+			// Success, stop trying to send the payload.
+			break
+		}
 
-    // Tell the registrar that we've successfully sent these events
-    registrar <- events
-  } /* for each event payload */
+		// Tell the registrar that we've successfully sent these events
+		registrar <- events
+	} /* for each event payload */
 } // Publish
 
 func connect(config *NetworkConfig) (socket *tls.Conn) {
-  var tlsconfig tls.Config
+	var tlsconfig tls.Config
 
-  if len(config.SSLCertificate) > 0 && len(config.SSLKey) > 0 {
-    log.Printf("Loading client ssl certificate: %s and %s\n",
-      config.SSLCertificate, config.SSLKey)
-    cert, err := tls.LoadX509KeyPair(config.SSLCertificate, config.SSLKey)
-    if err != nil {
-      log.Fatalf("Failed loading client ssl certificate: %s\n", err)
-    }
-    tlsconfig.Certificates = []tls.Certificate{cert}
-  }
+	if len(config.SSLCertificate) > 0 && len(config.SSLKey) > 0 {
+		log.Printf("Loading client ssl certificate: %s and %s\n",
+			config.SSLCertificate, config.SSLKey)
+		cert, err := tls.LoadX509KeyPair(config.SSLCertificate, config.SSLKey)
+		if err != nil {
+			log.Fatalf("Failed loading client ssl certificate: %s\n", err)
+		}
+		tlsconfig.Certificates = []tls.Certificate{cert}
+	}
 
-  if len(config.SSLCA) > 0 {
-    log.Printf("Setting trusted CA from file: %s\n", config.SSLCA)
-    tlsconfig.RootCAs = x509.NewCertPool()
+	if len(config.SSLCA) > 0 {
+		log.Printf("Setting trusted CA from file: %s\n", config.SSLCA)
+		tlsconfig.RootCAs = x509.NewCertPool()
 
-    pemdata, err := ioutil.ReadFile(config.SSLCA)
-    if err != nil {
-      log.Fatalf("Failure reading CA certificate: %s\n", err)
-    }
+		pemdata, err := ioutil.ReadFile(config.SSLCA)
+		if err != nil {
+			log.Fatalf("Failure reading CA certificate: %s\n", err)
+		}
 
-    block, _ := pem.Decode(pemdata)
-    if block == nil {
-      log.Fatalf("Failed to decode PEM data, is %s a valid cert?\n", config.SSLCA)
-    }
-    if block.Type != "CERTIFICATE" {
-      log.Fatalf("This is not a certificate file: %s\n", config.SSLCA)
-    }
+		block, _ := pem.Decode(pemdata)
+		if block == nil {
+			log.Fatalf("Failed to decode PEM data, is %s a valid cert?\n", config.SSLCA)
+		}
+		if block.Type != "CERTIFICATE" {
+			log.Fatalf("This is not a certificate file: %s\n", config.SSLCA)
+		}
 
-    cert, err := x509.ParseCertificate(block.Bytes)
-    if err != nil {
-      log.Fatalf("Failed to parse a certificate: %s\n", config.SSLCA)
-    }
-    tlsconfig.RootCAs.AddCert(cert)
-  }
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			log.Fatalf("Failed to parse a certificate: %s\n", config.SSLCA)
+		}
+		tlsconfig.RootCAs.AddCert(cert)
+		tlsconfig.InsecureSkipVerify = *insecure
+	}
 
-  for {
-    // Pick a random server from the list.
-    hostport := config.Servers[rand.Int()%len(config.Servers)]
-    submatch := hostport_re.FindSubmatch([]byte(hostport))
-    if submatch == nil {
-      log.Fatalf("Invalid host:port given: %s", hostport)
-    }
-    host := string(submatch[1])
-    port := string(submatch[2])
-    addresses, err := net.LookupHost(host)
+	for {
+		// Pick a random server from the list.
+		hostport := config.Servers[rand.Int()%len(config.Servers)]
+		submatch := hostport_re.FindSubmatch([]byte(hostport))
+		if submatch == nil {
+			log.Fatalf("Invalid host:port given: %s", hostport)
+		}
+		host := string(submatch[1])
+		port := string(submatch[2])
+		addresses, err := net.LookupHost(host)
 
-    if err != nil {
-      log.Printf("DNS lookup failure \"%s\": %s\n", host, err)
-      time.Sleep(1 * time.Second)
-      continue
-    }
+		if err != nil {
+			log.Printf("DNS lookup failure \"%s\": %s\n", host, err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
 
-    address := addresses[rand.Int()%len(addresses)]
-    addressport := fmt.Sprintf("%s:%s", address, port)
+		address := addresses[rand.Int()%len(addresses)]
+		addressport := fmt.Sprintf("%s:%s", address, port)
 
-    log.Printf("Connecting to %s (%s) \n", addressport, host)
+		log.Printf("Connecting to %s (%s) \n", addressport, host)
 
-    tcpsocket, err := net.DialTimeout("tcp", addressport, config.timeout)
-    if err != nil {
-      log.Printf("Failure connecting to %s: %s\n", address, err)
-      time.Sleep(1 * time.Second)
-      continue
-    }
+		tcpsocket, err := net.DialTimeout("tcp", addressport, config.timeout)
+		if err != nil {
+			log.Printf("Failure connecting to %s: %s\n", address, err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
 
-    socket = tls.Client(tcpsocket, &tlsconfig)
-    socket.SetDeadline(time.Now().Add(config.timeout))
-    err = socket.Handshake()
-    if err != nil {
-      log.Printf("Failed to tls handshake with %s %s\n", address, err)
-      time.Sleep(1 * time.Second)
-      socket.Close()
-      continue
-    }
+		socket = tls.Client(tcpsocket, &tlsconfig)
+		socket.SetDeadline(time.Now().Add(config.timeout))
+		err = socket.Handshake()
+		if err != nil {
+			log.Printf("Failed to tls handshake with %s %s\n", address, err)
+			time.Sleep(1 * time.Second)
+			socket.Close()
+			continue
+		}
 
-    log.Printf("Connected to %s\n", address)
+		log.Printf("Connected to %s\n", address)
 
-    // connected, let's rock and roll.
-    return
-  }
-  return
+		// connected, let's rock and roll.
+		return
+	}
+	return
 }
 
 func writeDataFrame(event *FileEvent, sequence uint32, output io.Writer) {
-  //log.Printf("event: %s\n", *event.Text)
-  // header, "1D"
-  output.Write([]byte("1D"))
-  // sequence number
-  binary.Write(output, binary.BigEndian, uint32(sequence))
-  // 'pair' count
-  binary.Write(output, binary.BigEndian, uint32(len(*event.Fields)+4))
+	//log.Printf("event: %s\n", *event.Text)
+	// header, "1D"
+	output.Write([]byte("1D"))
+	// sequence number
+	binary.Write(output, binary.BigEndian, uint32(sequence))
+	// 'pair' count
+	binary.Write(output, binary.BigEndian, uint32(len(*event.Fields)+4))
 
-  writeKV("file", *event.Source, output)
-  writeKV("host", hostname, output)
-  writeKV("offset", strconv.FormatInt(event.Offset, 10), output)
-  writeKV("line", *event.Text, output)
-  for k, v := range *event.Fields {
-    writeKV(k, v, output)
-  }
+	writeKV("file", *event.Source, output)
+	writeKV("host", hostname, output)
+	writeKV("offset", strconv.FormatInt(event.Offset, 10), output)
+	writeKV("line", *event.Text, output)
+	for k, v := range *event.Fields {
+		writeKV(k, v, output)
+	}
 }
 
 func writeKV(key string, value string, output io.Writer) {
-  //log.Printf("kv: %d/%s %d/%s\n", len(key), key, len(value), value)
-  binary.Write(output, binary.BigEndian, uint32(len(key)))
-  output.Write([]byte(key))
-  binary.Write(output, binary.BigEndian, uint32(len(value)))
-  output.Write([]byte(value))
+	//log.Printf("kv: %d/%s %d/%s\n", len(key), key, len(value), value)
+	binary.Write(output, binary.BigEndian, uint32(len(key)))
+	output.Write([]byte(key))
+	binary.Write(output, binary.BigEndian, uint32(len(value)))
+	output.Write([]byte(value))
 }

--- a/registrar_other.go
+++ b/registrar_other.go
@@ -3,22 +3,34 @@
 package main
 
 import (
-  "encoding/json"
-  "log"
-  "os"
+	"encoding/json"
+	"log"
+	"os"
 )
 
 func WriteRegistry(state map[string]*FileState, path string) {
-  // Open tmp file, write, flush, rename
-  file, err := os.Create(".logstash-forwarder.new")
-  if err != nil {
-    log.Printf("Failed to open .logstash-forwarder.new for writing: %s\n", err)
-    return
-  }
-  defer file.Close()
+	// load data from previous saved file
+	historical_state := make(map[string]*FileState)
+	history, err := os.Open(".logstash-forwarder")
+	if err == nil {
+		log.Printf("Loading old registrar data\n")
+		decoder := json.NewDecoder(history)
+		decoder.Decode(&historical_state)
+		history.Close()
+	}
+	// Open tmp file, write, flush, rename
+	file, err := os.Create(".logstash-forwarder.new")
+	if err != nil {
+		log.Printf("Failed to open .logstash-forwarder.new for writing: %s\n", err)
+		return
+	}
+	defer file.Close()
+	// update status with new events
+	for p, state := range state {
+		historical_state[p] = state
+	}
+	encoder := json.NewEncoder(file)
+	encoder.Encode(historical_state)
 
-  encoder := json.NewEncoder(file)
-  encoder.Encode(state)
-
-  os.Rename(".logstash-forwarder.new", path)
+	os.Rename(".logstash-forwarder.new", path)
 }

--- a/registrar_windows.go
+++ b/registrar_windows.go
@@ -1,24 +1,36 @@
 package main
 
 import (
-  "encoding/json"
-  "log"
-  "os"
+	"encoding/json"
+	"log"
+	"os"
 )
 
 func WriteRegistry(state map[string]*FileState, path string) {
-  tmp := path + ".new"
-  file, err := os.Create(tmp)
-  if err != nil {
-    log.Printf("Failed to open .logstash-forwarder.new for writing: %s\n", err)
-    return
-  }
+	// load data from previous saved file
+	historical_state := make(map[string]*FileState)
+	history, err := os.Open(path)
+	if err == nil {
+		decoder := json.NewDecoder(history)
+		decoder.Decode(&historical_state)
+		history.Close()
+	}
+	tmp := path + ".new"
+	file, err := os.Create(tmp)
+	if err != nil {
+		log.Printf("Failed to open %s for writing: %s\n", tmp, err)
+		return
+	}
+	// update status with new events
+	for p, state := range state {
+		historical_state[p] = state
+	}
 
-  encoder := json.NewEncoder(file)
-  encoder.Encode(state)
-  file.Close()
+	encoder := json.NewEncoder(file)
+	encoder.Encode(historical_state)
+	file.Close()
 
-  old := path + ".old"
-  os.Rename(path, old)
-  os.Rename(tmp, path)
+	old := path + ".old"
+	os.Rename(path, old)
+	os.Rename(tmp, path)
 }


### PR DESCRIPTION
1. add a command line option to disable TLS/SSL cert servername check, sometimes useful in an environment without DNS control
2. fixed problem of registrar will overwrite/lose status when monitoring
   multiple files
