### PR TITLE
Made x509 parse error on CA certs more explicit.

### DIFF
--- a/publisher1.go
+++ b/publisher1.go
@@ -161,7 +161,7 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 
     cert, err := x509.ParseCertificate(block.Bytes)
     if err != nil {
-      log.Fatalf("Failed to parse a certificate: %s\n", config.SSLCA)
+      log.Fatalf("Failed to parse CA certificate %s - %s\n", config.SSLCA, err)
     }
     tlsconfig.RootCAs.AddCert(cert)
   }


### PR DESCRIPTION
This is helpful for diagnosing issues with old CA certs (and potentially other issues) generated by GnuTLS which had invalid RSA modulus numbers (https://gitorious.org/gnutls/gnutls/commit/3d8da5765133c6ced37bf29b5a07f950b8c26cd7). We weren't actually aware of this issue with our old CA cert until provisioning logstash, so thanks! :smile:

In this specific case, error would now read:

    Failed to parse CA certificate /etc/ssl/cacert.pem - x509: RSA modulus is not a positive number

