### PR TITLE
Add handling for alternative logfile locations

### DIFF
--- a/logstash-forwarder.init
+++ b/logstash-forwarder.init
@@ -17,7 +17,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="log shipper"
 NAME=logstash-forwarder
 DAEMON=/opt/logstash-forwarder/bin/logstash-forwarder
-DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 -log-to-syslog"
+DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 -log-to-file -log-file /var/log/logstash-forwarder.log"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 


### PR DESCRIPTION
When using logstash-forwarder to ship syslog, it's not ideal to have it logging itself to syslog, especially as the volume of messages is very high. This patch adds configurable output for alternative log file locations. 
Not written anything in Go before, so apologies in advance for the code - it's probably not pretty, but it has been tested in our environment.