### PR TITLE
small fix for init script

### DIFF
--- a/logstash-forwarder.init
+++ b/logstash-forwarder.init
@@ -17,7 +17,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="log shipper"
 NAME=logstash-forwarder
 DAEMON=/opt/logstash-forwarder/bin/logstash-forwarder
-DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 -log-to-syslog"
+DAEMON_ARGS="-config="/etc/logstashforwarder/config.json" -spool-size 100 -log-to-syslog"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 


### PR DESCRIPTION
LS/F wouldn't autostart on Ubuntu 14.04; it would simply die without any notice (syslog was empty).
After attempting to manually start LSF with the same command from the init.d script I noticed a small error. This PR fixes that.

Tested on Ubuntu 14.04 Server LTS.