### PR TITLE
 add InsecureSkipVerify option (insecure skip verify)

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type NetworkConfig struct {
 	SSLCertificate string   `json:"ssl certificate"`
 	SSLKey         string   `json:"ssl key"`
 	SSLCA          string   `json:"ssl ca"`
+	InsecureSkipVerify bool `json:"insecure skip verify"` 
 	Timeout        int64    `json:timeout`
 	timeout        time.Duration
 }

--- a/publisher1.go
+++ b/publisher1.go
@@ -203,6 +203,9 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
     }
 
     tlsconfig.ServerName = host
+    if config.InsecureSkipVerify {
+       tlsconfig.InsecureSkipVerify = true
+    }
 
     socket = tls.Client(tcpsocket, &tlsconfig)
     socket.SetDeadline(time.Now().Add(config.timeout))


### PR DESCRIPTION
It is nice to have an easy way to set InsecureSkipVerify for go 1.3

I am still running into SSL issues on latest codebase and dont care for security yet as i'm in a lab. It should be easy to set this option.

This PR adds the following JSON option to the network section
<pre>
{
  "network": {
    "insecure skip verify": true,
}
</pre>