### PR TITLE
Corrected record offset sent via lumberjack.

### DIFF
--- a/harvester.go
+++ b/harvester.go
@@ -77,13 +77,14 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
     line++
     event := &FileEvent{
       Source: &h.Path,
-      Offset: offset,
+      Offset: h.Offset,
       Line: line,
       Text: text,
       Fields: &h.FileConfig.Fields,
       fileinfo: &info,
     }
     offset += int64(bytesread)
+    h.Offset += int64(bytesread)
 
     output <- event // ship the new event downstream
   } /* forever */

--- a/harvester.go
+++ b/harvester.go
@@ -77,7 +77,7 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
     line++
     event := &FileEvent{
       Source: &h.Path,
-      Offset: h.Offset,
+      Offset: offset,
       Line: line,
       Text: text,
       Fields: &h.FileConfig.Fields,

--- a/harvester.go
+++ b/harvester.go
@@ -83,7 +83,7 @@ func (h *Harvester) Harvest(output chan *FileEvent) {
       Fields: &h.FileConfig.Fields,
       fileinfo: &info,
     }
-    offset += int64(bytesread)
+    
     h.Offset += int64(bytesread)
 
     output <- event // ship the new event downstream


### PR DESCRIPTION
Updated the log harvester to ensure a unique offset is sent in the event for every line.