### PR TITLE
Explicit PID file name for status

### DIFF
--- a/logstash-forwarder.init
+++ b/logstash-forwarder.init
@@ -66,7 +66,7 @@ case "$1" in
     esac
     ;;
   status)
-    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
     ;;
   restart|force-reload)
     log_daemon_msg "Restarting $DESC" "$NAME"

--- a/logstash-forwarder.init
+++ b/logstash-forwarder.init
@@ -66,7 +66,7 @@ case "$1" in
     esac
     ;;
   status)
-    status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
   restart|force-reload)
     log_daemon_msg "Restarting $DESC" "$NAME"


### PR DESCRIPTION
If the base name of the PID file does not match the base name of the program, you have to specify the full PID file name explicitly.