### PR TITLE
allow user to manually set desired hostname 

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -20,6 +20,7 @@ var exitStat = struct {
 
 var options = &struct {
 	configArg           string
+	hostname            string
 	spoolSize           uint64
 	harvesterBufferSize int
 	cpuProfileFile      string
@@ -37,6 +38,7 @@ var options = &struct {
 func emitOptions() {
 	emit("\t--- options -------\n")
 	emit("\tconfig-arg:          %s\n", options.configArg)
+	emit("\thostname:            %s\n", options.hostname)
 	emit("\tidle-timeout:        %v\n", options.idleTimeout)
 	emit("\tspool-size:          %d\n", options.spoolSize)
 	emit("\tharvester-buff-size: %d\n", options.harvesterBufferSize)
@@ -63,6 +65,7 @@ const logflags = log.Ldate | log.Ltime | log.Lmicroseconds
 func init() {
 	flag.StringVar(&options.configArg, "config", options.configArg, "path to logstash-forwarder configuration file or directory")
 
+	flag.StringVar(&options.hostname, "hostname", options.hostname, "hostname we want to advertise as")
 	flag.StringVar(&options.cpuProfileFile, "cpuprofile", options.cpuProfileFile, "path to cpu profile output - note: exits on profile end.")
 
 	flag.Uint64Var(&options.spoolSize, "spool-size", options.spoolSize, "event count spool threshold - forces network flush")

--- a/publisher1.go
+++ b/publisher1.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -26,7 +27,16 @@ var hostname string
 var hostport_re, _ = regexp.Compile("^(.+):([0-9]+)$")
 
 func init() {
-	hostname, _ = os.Hostname()
+	var err error
+
+	hostname = options.hostname
+	if options.hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			log.Fatal("Hostname detection failed. Set -hostname flag or fix server's hostname reporting.",
+				err)
+		}
+	}
 	rand.Seed(time.Now().UnixNano())
 }
 


### PR DESCRIPTION
Hi, attached patch attempts to fix an issue (specially inside docker containers) where too often logstash-forwarder relays data with the short hostname as source (an alternative approach would be to just actually call hostname -f but here i kept using exclusively golang machinery in order to keep platform portability).