### PR TITLE
Prevent closing the wrong connection

### DIFF
--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -46,12 +46,15 @@ module Lumberjack
       while true
         # NOTE: This means ssl accepting is single-threaded.
         begin
+          client = nil
           client = @ssl_server.accept
         rescue EOFError, OpenSSL::SSL::SSLError, IOError
           # ssl handshake failure or other issue, skip it.
           # TODO(sissel): log the error
           # TODO(sissel): try to identify what client was connecting that failed.
-          client.close rescue nil
+          if !client.nil?
+            client.close rescue nil
+          end
           next
         end
 


### PR DESCRIPTION
In the event of an SSL error (eg, bad certificate from a client), `client` here still pointed to the last successful connection.
So when a client failed to connect, and `client` still pointed to the last successful connection, we were forcing that good connection to be closed.

This PR sets `client` to `nil`, before accepting a new connection, and then tests to make sure it's not `nil`, before closing it.

All credit to @keyurdg for spotting and fixing this.
