### PR TITLE
Add ability to read from directories of partial config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ include them in your config.:
       ]
     }
 
+Alternatively (or additionally), you may specify one or more directories from
+which to read the file configurations:
+
+    {
+      …
+      "includeFilesDirs": [
+        "/etc/logstash-forwarder.d"
+      ],
+      …
+    }
+  
+and with the following in `/etc/logstash-forwarder.d/syslog.json`:
+  
+    {
+      "paths": [
+        "/var/log/*.log",
+        "/var/log/messages"
+      ],
+      "fields": { "type": "syslog" }
+    }
+
 ### Goals
 
 * Minimize resource usage where possible (CPU, memory, network).


### PR DESCRIPTION
This adds the capability for specifying one or more directories from which FileConfig objects may be read.  This makes it easier to configure logstash-forwarder with CM tools.
