### PR TITLE
simplify install doc since forwarder is go-gettable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ include them in your config.:
 
 1. Install [go](http://golang.org/doc/install)
 
-2. Compile logstash-forwarder
+2. Download and build logstash-forwarder
 
-        git clone git://github.com/elasticsearch/logstash-forwarder.git
-        cd logstash-forwarder
-        go build
+    go get github.com/elasticsearch/logstash-forwarder
 
 ## Packaging it (optional)
 


### PR DESCRIPTION
I totally understand why it might make sense to keep the original phrasing, as this way requires a pre-existing `$GOPATH`. For potential developers who need `$GOPATH` set up anyway, that's great. For people just trying to install logstash-forwarder, that may be an unsafe assumption.