### PR TITLE
ignore directories inside the config dir

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,6 +54,9 @@ func DiscoverConfigs(file_or_directory string) (files []string, err error) {
 			return nil, err
 		}
 		for _, filename := range entries {
+			if filename.IsDir() {
+				continue
+			}
 			files = append(files, path.Join(file_or_directory, filename.Name()))
 		}
 	} else {


### PR DESCRIPTION
found this bug because puppet-logstashforwarder creates and 'ssl' dir in the configdir (to store local ssl certs if necessary). WRT to tests, this feature is covered by TestDiscoverConfigsAndIgnoreDirectories, however I have included TestLoadConfigAndIgnoreDirectories just to illustrate steps to reproduce.