### PR TITLE
Add command-line parameter to set the location of the registry file

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -215,7 +215,7 @@ func main() {
 	go Publishv1(publisher_chan, registrar_chan, &config.Network)
 
 	// registrar records last acknowledged positions in all files.
-	Registrar(persist, registrar_chan)
+	Registrar(persist, registrar_chan, options.registryFile)
 }
 
 // REVU: yes, this is a temp hack.

--- a/registrar.go
+++ b/registrar.go
@@ -28,7 +28,7 @@ func Registrar(state map[string]*FileState, input chan []*FileEvent) {
 			//log.Printf("State %s: %d\n", *event.Source, event.Offset)
 		}
 
-		if e := writeRegistry(state, ".logstash-forwarder"); e != nil {
+		if e := writeRegistry(state, options.registryFile); e != nil {
 			// REVU: but we should panic, or something, right?
 			emit("WARNING: (continuing) update of registry returned error: %s", e)
 		}

--- a/registrar.go
+++ b/registrar.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 )
 
-func Registrar(state map[string]*FileState, input chan []*FileEvent) {
+func Registrar(state map[string]*FileState, input chan []*FileEvent,
+	registryFile string) {
 	for events := range input {
 		emit ("Registrar: processing %d events\n", len(events))
 		// Take the last event found for each file source
@@ -28,7 +29,7 @@ func Registrar(state map[string]*FileState, input chan []*FileEvent) {
 			//log.Printf("State %s: %d\n", *event.Source, event.Offset)
 		}
 
-		if e := writeRegistry(state, options.registryFile); e != nil {
+		if e := writeRegistry(state, registryFile); e != nil {
 			// REVU: but we should panic, or something, right?
 			emit("WARNING: (continuing) update of registry returned error: %s", e)
 		}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io/ioutil"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func setupRegistrarTests(t *testing.T) (string, os.FileInfo) {
+	f, err := ioutil.TempFile("", "lsf-registrar")
+	if err != nil {
+		t.Error("Failed to create file", err)
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		t.Error("Failed to stat file", err)
+	}
+
+	return f.Name(), stat
+}
+
+func teardownRegistrarTests(f string) {
+	os.Remove(options.registryFile)
+	os.Remove(f)
+}
+
+func TestRegistrar(t *testing.T) {
+	file, stat := setupRegistrarTests(t)
+	defer teardownRegistrarTests(file)
+
+	testState := make(map[string]*FileState)
+	testInput := make(chan []*FileEvent)
+
+	mockEvents := []*FileEvent {
+		&FileEvent {
+			Source: &file,
+			Offset: 1024,
+			Text: &file,
+			fileinfo: &stat,
+		},
+	}
+
+	go func() {
+		testInput <- mockEvents
+		close(testInput)
+	}()
+
+	Registrar(testState, testInput)
+
+	rf, err := os.Open(options.registryFile)
+	if err != nil {
+		t.Fatal("Failed to open registry file", err)
+	}
+
+	registry := make(map[string]*FileState)
+	decoder := json.NewDecoder(rf)
+	decoder.Decode(&registry)
+
+	if ! reflect.DeepEqual(testState, registry) {
+		t.Fatalf("\nexpected: %s\ngot: %s\n", testState, registry)
+	}
+}
+


### PR DESCRIPTION
The registry file is always written to logstash-forwarder's working directory as a hidden file, .logstash-forwarder. This change makes this file relocatable. The default argument maintains the current behavior.