### PR TITLE
Add missing files for OpenBSD support

### DIFF
--- a/fileinfo_openbsd.go
+++ b/fileinfo_openbsd.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+  "os"
+  "syscall"
+)
+
+func file_ids(info *os.FileInfo) (uint64, int32) {
+  fstat := (*(info)).Sys().(*syscall.Stat_t)
+  return fstat.Ino, fstat.Dev
+}

--- a/filestate_openbsd.go
+++ b/filestate_openbsd.go
@@ -1,0 +1,9 @@
+package main
+
+type FileState struct {
+  Source *string `json:"source,omitempty"`
+  Offset int64 `json:"offset,omitempty"`
+  Inode uint64 `json:"inode,omitempty"`
+  Device int32 `json:"device,omitempty"`
+}
+


### PR DESCRIPTION
With these files in place logstash-forwarder builds and runs fine on OpenBSD. A port for OpenBSD will be added to the package tree shortly.

This PR that will also resolve #194 when merged.
