### PR TITLE
Add documentation on dead time

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ the only thing on the line:
 
           # A dictionary of fields to annotate on each event.
           "fields": { "type": "syslog" }
+
+          # how long to keep following a file if it's unchanged
+          # It will refollow the file if it changes but it closes 
+          # file handle. 
+          # example values: "300ms", "-1.5h" or "2h45m"
+          # valid units: "ns", "us" (or "µs"), "ms", "s", "m", "h".
+          "dead time": "1h"
         }, {
           # A path of "-" means stdin.
           "paths": [ "-" ],

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the only thing on the line:
           ],
 
           # A dictionary of fields to annotate on each event.
-          "fields": { "type": "syslog" }
+          "fields": { "type": "syslog" },
 
           # To save on resources (open files), logstash-forwarder will close file handles
           # on files that have not emitted new events after some time period.
@@ -90,6 +90,7 @@ the only thing on the line:
 
           # Valid units include "s" (seconds), "m" (minutes), and "h" (hours). 
           # For example, "30m" is 30 minutes and "1h30m" is 1 hour and 30 minutes
+          "dead time": "1h"
         }, {
           # A path of "-" means stdin.
           "paths": [ "-" ],

--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ the only thing on the line:
           # A dictionary of fields to annotate on each event.
           "fields": { "type": "syslog" }
 
-          # how long to keep following a file if it's unchanged
-          # It will refollow the file if it changes but it closes 
-          # file handle. 
-          # example values: "300ms", "-1.5h" or "2h45m"
-          # valid units: "ns", "us" (or "µs"), "ms", "s", "m", "h".
-          "dead time": "1h"
+          # To save on resources (open files), logstash-forwarder will close file handles
+          # on files that have not emitted new events after some time period.
+          # This setting controls that time period which we call 'dead time'.
+          # The file will still be monitored for new events, but just not as an
+          # open file.
+
+          # Valid units include "s" (seconds), "m" (minutes), and "h" (hours). 
+          # For example, "30m" is 30 minutes and "1h30m" is 1 hour and 30 minutes
         }, {
           # A path of "-" means stdin.
           "paths": [ "-" ],


### PR DESCRIPTION
There wasn't any documentation for this anywhere in the README I think.  I've added it in this commit.  It includes example values and valid units from the godocs. I didn't make an issue since it was just docs and pretty simple but let me know if you want me to and I can take care of it