### PR TITLE
Add a max-line-bytes flag which can be used to truncate messages before forwarding.

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -27,6 +27,7 @@ var options = &struct {
 	useSyslog           bool
 	tailOnRotate        bool
 	quiet               bool
+	maxLineBytes        int
   version bool
 }{
 	spoolSize:           1024,
@@ -42,8 +43,9 @@ func emitOptions() {
 	emit("\tharvester-buff-size: %d\n", options.harvesterBufferSize)
 	emit("\t--- flags ---------\n")
 	emit("\ttail (on-rotation):  %t\n", options.tailOnRotate)
-	emit("\tlog-to-syslog:          %t\n", options.useSyslog)
-	emit("\tquiet:             %t\n", options.quiet)
+	emit("\tlog-to-syslog:       %t\n", options.useSyslog)
+	emit("\tquiet:               %t\n", options.quiet)
+	emit("\tmax-line-bytes:      %d\n", options.maxLineBytes)
 	if runProfiler() {
 		emit("\t--- profile run ---\n")
 		emit("\tcpu-profile-file:    %s\n", options.cpuProfileFile)
@@ -79,6 +81,7 @@ func init() {
 
 	flag.BoolVar(&options.quiet, "quiet", options.quiet, "operate in quiet mode - only emit errors to log")
 	flag.BoolVar(&options.version, "version", options.version, "output the version of this program")
+	flag.IntVar(&options.maxLineBytes, "max-line-bytes", options.maxLineBytes, "max number of bytes forwarded per line - note: set to 0 for unlimited.")
 }
 
 func init() {


### PR DESCRIPTION
We're using logstash-forwarders to forward logs from applications that we don't control. Some times, these applications may log really large lines, in which case we'd like to both keep these from being transmitted to logstash and keep the logstash-forwarder from even materializing the really long string.

This patch adds a max-line-bytes flag. max-line-bytes defaults to 0, which preserves the current behavior of logstash-forwarders: no truncation of log lines at all. When set to something greater than 0, any line containing more than max-line-bytes bytes will be truncated to max-line-bytes before being forwarded to logstash and no more than max-line-bytes is held in the harvester's buffer when reading the line.

I ran `go test` and `rpsec` with the changes after running `go build`. All tests passed except for the "packaging make rpm should build an rpm" spec, which failed with or without this patch. I've signed a elastic contributor license agreement.