### PR TITLE
Added support for cross-compiling logstash-forwarder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ nacl.secret
 .lumberjack.new
 .rbx
 logstash-forwarder
+logstash-forwarder-*
 *.DS_Store
 *.idea
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CROSSARCH ?= amd64
-PKGARCH ?= amd64
+CROSSARCH ?=
+PKGARCH ?= native
 
 .PHONY: default
 default: logstash-forwarder

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-.PHONY: default
-default: compile
+CROSSARCH ?= amd64
+PKGARCH ?= amd64
 
-OBJECTS=logstash-forwarder
+.PHONY: default
+default: logstash-forwarder
+
+OBJECTS=logstash-forwarder logstash-forwarder-$(CROSSARCH)
 
 .PHONY: compile
 compile: $(OBJECTS)
 
 logstash-forwarder:
 	go build -o $@
+
+logstash-forwarder-$(CROSSARCH):
+	GOARCH=$(CROSSARCH) go build -o $@
 
 .PHONY: clean
 clean: 
@@ -36,7 +42,7 @@ rpm deb: PREFIX=/opt/logstash-forwarder
 rpm deb: VERSION=$(shell ./logstash-forwarder -version)
 rpm deb: compile generate-init-script build/empty
 	fpm -f -s dir -t $@ -n logstash-forwarder -v $(VERSION) \
-		--architecture native \
+		--architecture $(PKGARCH) \
 		--replaces lumberjack \
 		--description "a log shipping tool" \
 		--url "https://github.com/elasticsearch/logstash-forwarder" \
@@ -44,7 +50,7 @@ rpm deb: compile generate-init-script build/empty
 		--before-install $(BEFORE_INSTALL) \
 		--before-remove $(BEFORE_REMOVE) \
 		--config-files /etc/logstash-forwarder.conf \
-		./logstash-forwarder=$(PREFIX)/bin/ \
+		./logstash-forwarder-$(CROSSARCH)=$(PREFIX)/bin/logstash-forwarder \
 		./logstash-forwarder.conf.example=/etc/logstash-forwarder.conf \
 		./build/etc=/ \
 		./build/empty/=/var/lib/logstash-forwarder/ \


### PR DESCRIPTION
This makes some tweaks to make it easier to compile logstash-forwarder for a foreign processor architecture. My particular use case is building armhf (a Raspberry Pi, running Raspbian) on my desktop (an amd64 box running Ubuntu).

With this patch, you can cross-compile for Raspberry Pi by:
 * Building the Go cross-compiler from source (see http://dave.cheney.net/2013/07/09/an-introduction-to-cross-compilation-with-go-1-1)
 * Building logstash-forwader by doing:

````
CROSSARCH=arm PKGARCH=armhf make deb
````