### PR TITLE
When we parse invalid headers, we should raise an InvalidFrame Exception

### DIFF
--- a/lib/lumberjack/server.rb
+++ b/lib/lumberjack/server.rb
@@ -70,6 +70,8 @@ module Lumberjack
   end # class Server
 
   class Parser
+    class InvalidFrame < RuntimeError; end
+
     def initialize
       @buffer_offset = 0
       @buffer = ""
@@ -146,7 +148,8 @@ module Lumberjack
       when FRAME_WINDOW; transition(:window_size, 4)
       when FRAME_DATA; transition(:data_lead, 8)
       when FRAME_COMPRESSED; transition(:compressed_lead, 4)
-      else; raise "Unknown frame type: #{frame_type}"
+      else
+        raise InvalidFrame, "Unknown frame type: #{frame_type}"
       end
     end
 
@@ -255,5 +258,4 @@ module Lumberjack
       end
     end
   end # class Connection
-
 end # module Lumberjack

--- a/spec/lumberjack/client_spec.rb
+++ b/spec/lumberjack/client_spec.rb
@@ -62,6 +62,21 @@ describe "Lumberjack::Client" do
     end
   end
 
+  describe Lumberjack::Parser do
+    let(:invalid_frame) { "NOT VALID AT ALL" }
+    subject { Lumberjack::Parser.new }
+
+    context "invalid frames" do
+      before do
+        expect(subject).to receive(:get).and_return(invalid_frame)
+      end
+
+      it "raises an exception" do
+        expect { subject.header }.to raise_error(Lumberjack::Parser::InvalidFrame)
+      end
+    end
+  end
+
   describe Lumberjack::Encoder do
     it 'should creates frames without truncating accentued characters' do
       content = {


### PR DESCRIPTION
Raise a concrete exception instead of a RuntimeError on invalid header frame.

Ref: https://github.com/elastic/logstash/issues/3138
and this PR: https://github.com/logstash-plugins/logstash-input-lumberjack/pull/8/files