### PR TITLE
Only perform DNS lookup for hostnames.

### DIFF
--- a/publisher1.go
+++ b/publisher1.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/pem"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -183,14 +182,9 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 		}
 
 		address := addresses[rand.Int()%len(addresses)]
-		var addressport string
+		addressport := net.JoinHostPort(address, port)
 
 		ip := net.ParseIP(address)
-		if len(ip) == net.IPv4len {
-			addressport = fmt.Sprintf("%s:%s", address, port)
-		} else if len(ip) == net.IPv6len {
-			addressport = fmt.Sprintf("[%s]:%s", address, port)
-		}
 
 		emit("Connecting to %s (%s) \n", addressport, host)
 

--- a/publisher1.go
+++ b/publisher1.go
@@ -173,18 +173,21 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 		}
 		host := string(submatch[1])
 		port := string(submatch[2])
-		addresses, err := net.LookupHost(host)
 
-		if err != nil {
-			emit("DNS lookup failure \"%s\": %s\n", host, err)
-			time.Sleep(1 * time.Second)
-			continue
+		var address string
+		if net.ParseIP(host) != nil {
+			address = host
+		} else {
+			addresses, err := net.LookupHost(host)
+			if err != nil {
+				emit("DNS lookup failure \"%s\": %s\n", host, err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			address = addresses[rand.Int()%len(addresses)]
 		}
-
-		address := addresses[rand.Int()%len(addresses)]
 		addressport := net.JoinHostPort(address, port)
-
-		ip := net.ParseIP(address)
 
 		emit("Connecting to %s (%s) \n", addressport, host)
 

--- a/publisher1.go
+++ b/publisher1.go
@@ -136,7 +136,7 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 			config.SSLCertificate, config.SSLKey)
 		cert, err := tls.LoadX509KeyPair(config.SSLCertificate, config.SSLKey)
 		if err != nil {
-			fault ("Failed loading client ssl certificate: %s\n", err)
+			fault("Failed loading client ssl certificate: %s\n", err)
 		}
 		tlsconfig.Certificates = []tls.Certificate{cert}
 	}


### PR DESCRIPTION
Closing bug #371 which under some circumstances caused IP addresses
to fail the DNS lookup, plus a couple of other minor fixups.