### PR TITLE
added ability to set working directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,8 +22,9 @@ var defaultConfig = &struct {
 }
 
 type Config struct {
-	Network NetworkConfig `json:network`
-	Files   []FileConfig  `json:files`
+	Network    NetworkConfig `json:network`
+	Files      []FileConfig  `json:files`
+	WorkingDir string        `json:workingDir`
 }
 
 type NetworkConfig struct {

--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"runtime/pprof"
 	"time"
-  "fmt"
 )
 
 var exitStat = struct {
@@ -27,7 +27,7 @@ var options = &struct {
 	useSyslog           bool
 	tailOnRotate        bool
 	quiet               bool
-  version bool
+	version             bool
 }{
 	spoolSize:           1024,
 	harvesterBufferSize: 16 << 10,
@@ -97,7 +97,7 @@ func main() {
 	flag.Parse()
 
 	if options.version {
-		fmt.Println(Version);
+		fmt.Println(Version)
 		return
 	}
 
@@ -208,7 +208,7 @@ func main() {
 	go Publishv1(publisher_chan, registrar_chan, &config.Network)
 
 	// registrar records last acknowledged positions in all files.
-	Registrar(persist, registrar_chan)
+	Registrar(persist, registrar_chan, config.WorkingDir)
 }
 
 // REVU: yes, this is a temp hack.

--- a/registrar.go
+++ b/registrar.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"os"
 	"encoding/json"
+	"os"
+	"path"
 )
 
-func Registrar(state map[string]*FileState, input chan []*FileEvent) {
+func Registrar(state map[string]*FileState, input chan []*FileEvent, workingDir string) {
 	for events := range input {
-		emit ("Registrar: processing %d events\n", len(events))
+		emit("Registrar: processing %d events\n", len(events))
 		// Take the last event found for each file source
 		for _, event := range events {
 			// skip stdin
@@ -28,7 +29,7 @@ func Registrar(state map[string]*FileState, input chan []*FileEvent) {
 			//log.Printf("State %s: %d\n", *event.Source, event.Offset)
 		}
 
-		if e := writeRegistry(state, ".logstash-forwarder"); e != nil {
+		if e := writeRegistry(state, path.Join(workingDir, ".logstash-forwarder")); e != nil {
 			// REVU: but we should panic, or something, right?
 			emit("WARNING: (continuing) update of registry returned error: %s", e)
 		}


### PR DESCRIPTION
Added the ability to set the working directory for files that are saved to the file system. 

Alleviates the following error:
Failed to create tempfile (.logstash-forwarder.new) for writing: open .logstash-forwarder.new: permission denied.

Generally the practice of writing files to the same folder as the binary should be avoided.
