### PR TITLE
Add Idle Timeout CLI Argument

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -68,6 +68,9 @@ func init() {
 	flag.Uint64Var(&options.spoolSize, "spool-size", options.spoolSize, "event count spool threshold - forces network flush")
 	flag.Uint64Var(&options.spoolSize, "sv", options.spoolSize, "event count spool threshold - forces network flush")
 
+	flag.DurationVar(&options.idleTimeout, "idle-timeout", options.idleTimeout, "The maximum time an event can stay spooled before it is flushed (default: 5s)")
+	flag.DurationVar(&options.idleTimeout, "it", options.idleTimeout, "The maximum time an event can stay spooled before it is flushed (default: 5s)")
+
 	flag.IntVar(&options.harvesterBufferSize, "harvest-buffer-size", options.harvesterBufferSize, "harvester reader buffer size")
 	flag.IntVar(&options.harvesterBufferSize, "hb", options.harvesterBufferSize, "harvester reader buffer size")
 

--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -68,8 +68,8 @@ func init() {
 	flag.Uint64Var(&options.spoolSize, "spool-size", options.spoolSize, "event count spool threshold - forces network flush")
 	flag.Uint64Var(&options.spoolSize, "sv", options.spoolSize, "event count spool threshold - forces network flush")
 
-	flag.DurationVar(&options.idleTimeout, "idle-timeout", options.idleTimeout, "The maximum time an event can stay spooled before it is flushed (default: 5s)")
-	flag.DurationVar(&options.idleTimeout, "it", options.idleTimeout, "The maximum time an event can stay spooled before it is flushed (default: 5s)")
+	flag.DurationVar(&options.idleTimeout, "idle-timeout", options.idleTimeout, "maximum time an event stays spooled before it's flushed")
+	flag.DurationVar(&options.idleTimeout, "it", options.idleTimeout, "maximum time an event stays spooled before it's flushed")
 
 	flag.IntVar(&options.harvesterBufferSize, "harvest-buffer-size", options.harvesterBufferSize, "harvester reader buffer size")
 	flag.IntVar(&options.harvesterBufferSize, "hb", options.harvesterBufferSize, "harvester reader buffer size")


### PR DESCRIPTION
Adds the ability to customize options.idleTimeout via the cli using
either the -idle-timeout or -it flags. The value of these flags must
be acceptable to time.ParseDuration, for example: -idle-timeout 1s

See Issue [#460](https://github.com/elastic/logstash-forwarder/issues/460)

PS: couldn't get test harness working on my machine.  Would like / a pointer to some docs on running tests for LF
