### PR TITLE
Add Windows Support for the .logstash-forwarder file from overwrite to rewrite

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -162,8 +162,7 @@ func main() {
 
 	// Load the previous log file locations now, for use in prospector
 	restart.files = make(map[string]*FileState)
-	if existing, e := os.Open(".logstash-forwarder"); e == nil {
-		defer existing.Close()
+	if existing, e := os.OpenFile(".logstash-forwarder", os.O_RDONLY | os.O_CREATE, 0666); e == nil {
 		wd := ""
 		if wd, e = os.Getwd(); e != nil {
 			emit("WARNING: os.Getwd retuned unexpected error %s -- ignoring\n", e.Error())
@@ -172,6 +171,7 @@ func main() {
 
 		decoder := json.NewDecoder(existing)
 		decoder.Decode(&restart.files)
+		existing.Close()
 	}
 
 	pendingProspectorCnt := 0

--- a/registrar.go
+++ b/registrar.go
@@ -42,10 +42,11 @@ func writeRegistry(state map[string]*FileState, path string) error {
 		emit("Failed to create tempfile (%s) for writing: %s\n", tempfile, e)
 		return e
 	}
-	defer file.Close()
 
 	encoder := json.NewEncoder(file)
 	encoder.Encode(state)
+
+	file.Close()
 
 	return onRegistryWrite(path, tempfile)
 }

--- a/registrar_windows.go
+++ b/registrar_windows.go
@@ -8,6 +8,7 @@ func onRegistryWrite(path, tempfile string) error {
 	old := path + ".old"
 	var e error
 	
+	os.Remove(old);
 	if e = os.Rename(path, old); e != nil {
 		emit("registry rotate: rename of %s to %s - %s\n", path, old, e)
 		return e


### PR DESCRIPTION
This code was taken from [Pull Request 273](https://github.com/elastic/logstash-forwarder/pull/273/)

I am using the latest logstash-forwarder version though, because the implementation of Pull Request 273 fails with this version.

I am fairly new to GitHub, so here is the message from sdgroot:

Here is what 
Due to the use of the 'defer' keyword, file handles were kept open too long. This resulted in the error 'The process cannot access the file because it is being used by another process.'.

Another addition is for opening the file .logstash-forwarder. Initially this file will not exist. The Registar for Windows assumes this file exists. Therefore we explicitly tell the OS to create the file when it doesn't exist yet.

See also https://groups.google.com/forum/#!topic/logstash-users/oFDcoGj8Qtc