### PR TITLE
Log TLS handshake errors even when the -quiet flag is used

### DIFF
--- a/logstash-forwarder.go
+++ b/logstash-forwarder.go
@@ -219,6 +219,10 @@ func emit(msgfmt string, args ...interface{}) {
 	log.Printf(msgfmt, args...)
 }
 
+func emitEvenInQuietMode(msgfmt string, args ...interface{}) {
+	log.Printf(msgfmt, args...)
+}
+
 func fault(msgfmt string, args ...interface{}) {
 	exit(exitStat.faulted, msgfmt, args...)
 }

--- a/publisher1.go
+++ b/publisher1.go
@@ -207,7 +207,7 @@ func connect(config *NetworkConfig) (socket *tls.Conn) {
 		socket.SetDeadline(time.Now().Add(config.timeout))
 		err = socket.Handshake()
 		if err != nil {
-			emit("Failed to tls handshake with %s %s\n", address, err)
+			emitEvenInQuietMode("Failed to tls handshake with %s %s\n", address, err)
 			time.Sleep(1 * time.Second)
 			socket.Close()
 			continue


### PR DESCRIPTION
Fixes #501

This is a bit of a quick fix. Would be good to get some input on how we should handle printing/not printing errors regardless of quiet mode being enabled. There are probably other places where we'd like to log a message because the error is sufficiently important.

The issue referenced (#501) makes debugging issues in production particularly difficult, where the `-quiet` flag is essential to avoid filling up disks with info messages.