### PR TITLE
changes to makefile to package an RPM that uses a conf.d config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ generate-init-script:
 	pleaserun --install --no-install-actions --install-prefix ./build \
 		--chdir /var/lib/logstash-forwarder \
 		--sysv-log-path /var/log/logstash-forwarder/ \
-		--overwrite -p sysv -v lsb-3.1 $(PREFIX)/bin/logstash-forwarder -config /etc/logstash-forwarder.conf
+		--overwrite -p sysv -v lsb-3.1 $(PREFIX)/bin/logstash-forwarder -config /etc/logstash-forwarder.conf.d
+
  
 build/empty: | build
 	mkdir $@
@@ -43,9 +44,9 @@ rpm deb: compile generate-init-script build/empty
 		--after-install $(AFTER_INSTALL) \
 		--before-install $(BEFORE_INSTALL) \
 		--before-remove $(BEFORE_REMOVE) \
-		--config-files /etc/logstash-forwarder.conf \
+		--config-files /etc/logstash-forwarder.conf.d \
 		./logstash-forwarder=$(PREFIX)/bin/ \
-		./logstash-forwarder.conf.example=/etc/logstash-forwarder.conf \
+		./logstash-forwarder.conf.example=/etc/logstash-forwarder.conf.d/logstash-forwarder.conf \
 		./build/etc=/ \
 		./build/empty/=/var/lib/logstash-forwarder/ \
 		./build/empty/=/var/log/logstash-forwarder/ \


### PR DESCRIPTION
There seemed to be no good reason for new installations of logstash forwarder to use a straight config file.  This PR has the Makefile drop the example config in a conf.d dir and tells pleaserun to use that instead for an arg.