### PR TITLE
made the PORT numbers same in both CONF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the only thing on the line:
         # A list of downstream servers listening for our messages.
         # logstash-forwarder will pick one at random and only switch if
         # the selected one appears to be dead or unresponsive
-        "servers": [ "localhost:5043" ],
+        "servers": [ "localhost:12345" ],
 
         # The path to your client ssl certificate (optional)
         "ssl certificate": "./logstash-forwarder.crt",


### PR DESCRIPTION
this reduces the ambiguity for new users. so they can understand that it is one port. The same port number 12345 is used in both logstash-forwarder.conf and logstash.conf configuration files. Explicitly mentioned to reduce ambiguity.