### PR TITLE
Edited misspelled word.

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -10,7 +10,7 @@ However, this document (the protocol documentation) has fallen out of date with 
 
 The needs that lead to this protocol are:
 
-* Encryption amd Authentication to protect
+* Encryption and Authentication to protect
 * Compression should be used to reduce bandwidth
 * Round-trip latency should not damage throughput
 * Application-level message acknowledgement


### PR DESCRIPTION
Under the End disclaimer section, it seems `amd` intended to say `and`.